### PR TITLE
Replacing UIEvent.which deprecated property by MouseEvent.button

### DIFF
--- a/lib/router-events/patch-router/link.tsx
+++ b/lib/router-events/patch-router/link.tsx
@@ -13,7 +13,7 @@ function isModifiedEvent(event: React.MouseEvent): boolean {
     event.ctrlKey ||
     event.shiftKey ||
     event.altKey || // triggers resource download
-    (event.nativeEvent && event.nativeEvent.which === 2)
+    (event.nativeEvent && event.nativeEvent.button === 1)
   );
 }
 


### PR DESCRIPTION
Replacing [which property](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which) by [button property](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button)